### PR TITLE
prefill social care id from url

### DIFF
--- a/components/StartForm.test.tsx
+++ b/components/StartForm.test.tsx
@@ -1,5 +1,22 @@
 import StartForm from "./StartForm"
 import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { useRouter } from "next/router"
+
+jest.mock("next/router")
+;(useRouter as jest.Mock)
+  .mockReturnValueOnce({
+    query: {},
+  })
+  .mockReturnValueOnce({
+    query: {
+      social_care_id: 123,
+    },
+  })
+  .mockReturnValueOnce({
+    query: {},
+  })
+
+const mockHandler = jest.fn()
 
 describe("StartForm", () => {
   it("renders the correct fields", () => {
@@ -22,6 +39,33 @@ describe("StartForm", () => {
     )
     expect(screen.getByLabelText("Social care ID"))
     expect(screen.getByLabelText("What do you want to start?"))
+  })
+
+  it("prefills a social care id from the url", async () => {
+    render(
+      <StartForm
+        forms={[
+          {
+            id: "foo",
+            name: "Foo",
+            steps: [],
+          },
+        ]}
+        onSubmit={mockHandler}
+      />
+    )
+
+    expect(screen.queryAllByLabelText("Social care ID").length).toBe(0)
+    fireEvent.click(screen.getByText("Continue"))
+    await waitFor(() => {
+      expect(mockHandler).toBeCalledWith(
+        {
+          socialCareId: 123,
+          formId: "foo",
+        },
+        expect.anything()
+      )
+    })
   })
 
   it("shows an error if submission fails", async () => {

--- a/components/StartForm.tsx
+++ b/components/StartForm.tsx
@@ -6,6 +6,7 @@ import TextField from "./TextField"
 import SelectField from "./SelectField"
 import { formsToChoices } from "../lib/helpers"
 import Banner from "./Banner"
+import { useRouter } from "next/router"
 
 interface Props {
   forms: FormType[]
@@ -15,12 +16,14 @@ interface Props {
 const StartForm = ({ forms, onSubmit }: Props): React.ReactElement => {
   const formsToChoicesCallback = useCallback(formsToChoices, [forms])
 
+  const { query } = useRouter()
+
   const choices = formsToChoicesCallback(forms)
 
   return (
     <Formik
       initialValues={{
-        socialCareId: "",
+        socialCareId: query.social_care_id || "",
         formId: choices[0].value,
       }}
       validationSchema={startSchema}
@@ -38,14 +41,16 @@ const StartForm = ({ forms, onSubmit }: Props): React.ReactElement => {
             </Banner>
           )}
 
-          <TextField
-            name="socialCareId"
-            label="Social care ID"
-            hint="For example, 12345678"
-            touched={touched}
-            errors={errors}
-            className="govuk-input--width-10"
-          />
+          {!query.social_care_id && (
+            <TextField
+              name="socialCareId"
+              label="Social care ID"
+              hint="For example, 12345678"
+              touched={touched}
+              errors={errors}
+              className="govuk-input--width-10"
+            />
+          )}
 
           <SelectField
             name="formId"


### PR DESCRIPTION
this improvement makes it easier to kick-off a new form from single view by:

- having the "new" form detect whether a social care id has been supplied in the url
- hide the social care id field from the form if so, and use the url-supplied value insterad