### PR TITLE
add revision history

### DIFF
--- a/components/RevisionTimeline.test.tsx
+++ b/components/RevisionTimeline.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react"
+import RevisionTimeline from "./RevisionTimeline"
+
+describe("RevisionTimeline", () => {
+  it("renders correctly", () => {
+    render(
+      <RevisionTimeline
+        revisions={[
+          {
+            id: "1",
+            submissionId: "1",
+            createdBy: "test@user.com",
+            completedSteps: ["one", "two"],
+            createdAt: "2021-04-14T14:15:00.00" as unknown as Date,
+          },
+          {
+            id: "2",
+            submissionId: "1",
+            createdBy: "test2@user.com",
+            completedSteps: ["one"],
+            createdAt: "2021-04-13T10:00:00.00" as unknown as Date,
+          },
+        ]}
+        totalSteps={3}
+      />
+    )
+
+    expect(screen.queryAllByRole("listitem").length).toBe(2)
+
+    expect(screen.getByText("test@user.com"))
+    expect(screen.getByText("14 Apr 2021 2.15 PM (67%)"))
+
+    expect(screen.getByText("test2@user.com"))
+    expect(screen.getByText("13 Apr 2021 10.00 AM (33%)"))
+  })
+})

--- a/components/RevisionTimeline.tsx
+++ b/components/RevisionTimeline.tsx
@@ -10,22 +10,26 @@ interface Props {
 const RevisionTimeline = ({
   revisions,
   totalSteps,
-}: Props): React.ReactElement => (
-  <ol className={`lbh-timeline ${s.timeline}`}>
-    {revisions.map(revision => (
-      <li
-        className={`lbh-timeline__event lbh-timeline__event--minor ${s.event}`}
-        key={revision.id}
-      >
-        <h3 className="lbh-body">{revision.createdBy}</h3>
+}: Props): React.ReactElement => {
+  if (!revisions || revisions.length === 0) return null
 
-        <p className="lbh-body-xs">
-          {prettyDateAndTime(revision.createdAt.toString())} (
-          {Math.round((revision.completedSteps.length / totalSteps) * 100)}%)
-        </p>
-      </li>
-    ))}
-  </ol>
-)
+  return (
+    <ol className={`lbh-timeline ${s.timeline}`}>
+      {revisions.map(revision => (
+        <li
+          className={`lbh-timeline__event lbh-timeline__event--minor ${s.event}`}
+          key={revision.id}
+        >
+          <h3 className="lbh-body">{revision.createdBy}</h3>
+
+          <p className="lbh-body-xs">
+            {prettyDateAndTime(revision.createdAt.toString())} (
+            {Math.round((revision.completedSteps.length / totalSteps) * 100)}%)
+          </p>
+        </li>
+      ))}
+    </ol>
+  )
+}
 
 export default RevisionTimeline

--- a/components/RevisionTimeline.tsx
+++ b/components/RevisionTimeline.tsx
@@ -1,0 +1,31 @@
+import { prettyDateAndTime } from "../lib/formatters"
+import { Revision } from "@prisma/client"
+import s from "../styles/RevisionTimeline.module.scss"
+
+interface Props {
+  revisions: Revision[]
+  totalSteps: number
+}
+
+const RevisionTimeline = ({
+  revisions,
+  totalSteps,
+}: Props): React.ReactElement => (
+  <ol className={`lbh-timeline ${s.timeline}`}>
+    {revisions.map(revision => (
+      <li
+        className={`lbh-timeline__event lbh-timeline__event--minor ${s.event}`}
+        key={revision.id}
+      >
+        <h3 className="lbh-body">{revision.createdBy}</h3>
+
+        <p className="lbh-body-xs">
+          {prettyDateAndTime(revision.createdAt.toString())} (
+          {Math.round((revision.completedSteps.length / totalSteps) * 100)}%)
+        </p>
+      </li>
+    ))}
+  </ol>
+)
+
+export default RevisionTimeline

--- a/components/SubmissionRow.test.tsx
+++ b/components/SubmissionRow.test.tsx
@@ -10,7 +10,7 @@ const mockSubmission = {
   createdBy: "example@email.com",
   answers: {},
   editedBy: ["example@email.com", "foo@bar.com"],
-  createdAt: ("2021-04-14T10:14:00.87" as unknown) as Date,
+  createdAt: "2021-04-14T10:14:00.87" as unknown as Date,
   updatedAt: new Date(),
   discardedAt: null,
   submittedAt: null,
@@ -20,6 +20,7 @@ const mockSubmission = {
     name: "Foo form",
     steps: [],
   },
+  revisions: [],
 }
 
 describe("SubmissionRow", () => {

--- a/components/SubmissionRow.tsx
+++ b/components/SubmissionRow.tsx
@@ -1,11 +1,20 @@
 import Link from "next/link"
-import { Submission } from "@prisma/client"
+import { Prisma } from "@prisma/client"
 import { prettyDate, prettyDateAndTime } from "../lib/formatters"
 import s from "../styles/SubmissionsTable.module.scss"
 import { Form } from "../config/forms.types"
 import DiscardDialog from "../components/DiscardDialog"
+import RevisionTimeline from "./RevisionTimeline"
 
-export interface SubmissionWithForm extends Submission {
+const submissionWithRevision = Prisma.validator<Prisma.SubmissionArgs>()({
+  include: { Revision: true },
+})
+
+type SubmissionWithRevision = Prisma.SubmissionGetPayload<
+  typeof submissionWithRevision
+>
+
+export interface SubmissionWithForm extends SubmissionWithRevision {
   form: Form
 }
 
@@ -30,11 +39,6 @@ const SubmissionRow = ({
       <tr className={`govuk-table__row ${s.row}`}>
         <td className="govuk-table__cell">{submission.socialCareId}</td>
         <td className="govuk-table__cell">
-          {/* <meter
-          className={s.meter}
-          value={submission.completedSteps.length}
-          max={submission.form.steps.length}
-        /> */}
           <Link
             href={
               submission.form.steps.length > 1
@@ -122,6 +126,11 @@ const SubmissionRow = ({
                   <dt className="lbh-body-s">Editors</dt>
                 </div>
               )}
+
+              <RevisionTimeline
+                revisions={submission.Revision}
+                totalSteps={submission.form.steps.length}
+              />
             </dl>
 
             <DiscardDialog submissionId={submission.id} />

--- a/components/SubmissionRow.tsx
+++ b/components/SubmissionRow.tsx
@@ -7,7 +7,7 @@ import DiscardDialog from "../components/DiscardDialog"
 import RevisionTimeline from "./RevisionTimeline"
 
 const submissionWithRevision = Prisma.validator<Prisma.SubmissionArgs>()({
-  include: { Revision: true },
+  include: { revisions: true },
 })
 
 type SubmissionWithRevision = Prisma.SubmissionGetPayload<
@@ -128,7 +128,7 @@ const SubmissionRow = ({
               )}
 
               <RevisionTimeline
-                revisions={submission.Revision}
+                revisions={submission.revisions}
                 totalSteps={submission.form.steps.length}
               />
             </dl>

--- a/components/SubmissionsTable.test.tsx
+++ b/components/SubmissionsTable.test.tsx
@@ -13,7 +13,7 @@ describe("SubmissionsTable", () => {
             createdBy: "example@email.com",
             answers: {},
             editedBy: [],
-            createdAt: ("2021-04-14T10:14:00.87" as unknown) as Date,
+            createdAt: "2021-04-14T10:14:00.87" as unknown as Date,
             updatedAt: new Date(),
             submittedAt: null,
             discardedAt: null,
@@ -23,6 +23,7 @@ describe("SubmissionsTable", () => {
               name: "Foo form",
               steps: [],
             },
+            revisions: [],
           },
         ]}
       />

--- a/components/SubmissionsTable.tsx
+++ b/components/SubmissionsTable.tsx
@@ -1,9 +1,17 @@
 import { useState } from "react"
-import { Submission } from "@prisma/client"
+import { Prisma } from "@prisma/client"
 import { Form } from "../config/forms.types"
 import SubmissionRow from "./SubmissionRow"
 
-export interface SubmissionWithForm extends Submission {
+const submissionWithRevision = Prisma.validator<Prisma.SubmissionArgs>()({
+  include: { revisions: true },
+})
+
+type SubmissionWithRevision = Prisma.SubmissionGetPayload<
+  typeof submissionWithRevision
+>
+
+export interface SubmissionWithForm extends SubmissionWithRevision {
   form: Form
 }
 

--- a/config/app.ts
+++ b/config/app.ts
@@ -1,0 +1,10 @@
+const config: Config = {
+  /** How many milliseconds must have passed before a new revision of a form is saved?  */
+  revisionInterval: 1000 * 60 * 5,
+}
+
+interface Config {
+  revisionInterval: number
+}
+
+export default config

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -17,6 +17,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         orderBy: {
           createdAt: "desc",
         },
+        take: 3,
       },
     },
   })

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -12,6 +12,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     orderBy: {
       updatedAt: "desc",
     },
+    include: {
+      Revision: {
+        orderBy: {
+          createdAt: "desc",
+        },
+      },
+    },
   })
 
   res.json({

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -13,7 +13,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       updatedAt: "desc",
     },
     include: {
-      Revision: {
+      revisions: {
         orderBy: {
           createdAt: "desc",
         },

--- a/pages/api/submissions/[id]/steps/[stepId].tsx
+++ b/pages/api/submissions/[id]/steps/[stepId].tsx
@@ -36,6 +36,21 @@ const handler = async (req: ApiRequestWithSession, res: NextApiResponse) => {
     const updatedAnswers = submission.answers || {}
     updatedAnswers[stepId.toString()] = values
 
+    // // get the last revision, if it exists
+    // const lastRevision = await prisma.revision.findFirst({
+    //   where: {
+    //     submissionId: id.toString(),
+    //   },
+    //   orderBy: {
+    //     createdAt: "desc",
+    //   },
+    // })
+
+    const completedSteps = pushUnique(
+      submission.completedSteps,
+      stepId.toString()
+    )
+
     const updatedSubmission = await prisma.submission.update({
       where: {
         id: id.toString(),
@@ -43,10 +58,15 @@ const handler = async (req: ApiRequestWithSession, res: NextApiResponse) => {
       data: {
         answers: updatedAnswers,
         editedBy: pushUnique(submission.editedBy, req.session.user.email),
-        completedSteps: pushUnique(
-          submission.completedSteps,
-          stepId.toString()
-        ),
+        completedSteps,
+        Revision: {
+          create: [
+            {
+              createdBy: req.session.user.email,
+              completedSteps,
+            },
+          ],
+        },
       },
     })
 

--- a/pages/api/submissions/[id]/steps/[stepId].tsx
+++ b/pages/api/submissions/[id]/steps/[stepId].tsx
@@ -67,7 +67,7 @@ const handler = async (req: ApiRequestWithSession, res: NextApiResponse) => {
         editedBy: pushUnique(submission.editedBy, req.session.user.email),
         completedSteps,
         // save a revision, conditionally
-        Revision: shouldSaveRevision
+        revisions: shouldSaveRevision
           ? {
               create: [
                 {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,7 +19,7 @@ model Submission {
   updatedAt      DateTime   @updatedAt
   submittedAt    DateTime?
   discardedAt    DateTime?
-  Revision       Revision[]
+  revisions      Revision[]
 }
 
 model Revision {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,25 +8,25 @@ generator client {
 }
 
 model Submission {
-  id             String    @id @default(cuid())
+  id             String     @id @default(cuid())
   socialCareId   Int
   formId         String
-  answers        Json      @default("{}")
+  answers        Json       @default("{}")
   completedSteps String[]
   editedBy       String[]
   createdBy      String
-  createdAt      DateTime  @default(now())
-  updatedAt      DateTime  @updatedAt
+  createdAt      DateTime   @default(now())
+  updatedAt      DateTime   @updatedAt
   submittedAt    DateTime?
   discardedAt    DateTime?
-  // Revision       Revision[]
+  Revision       Revision[]
 }
 
-// model Revision {
-//   id             String     @id @default(cuid())
-//   completedSteps String[]
-//   createdBy      String
-//   createdAt      DateTime   @default(now())
-//   submissionId   String
-//   submission     Submission @relation(fields: [submissionId], references: [id])
-// }
+model Revision {
+  id             String     @id @default(cuid())
+  completedSteps String[]
+  createdBy      String
+  createdAt      DateTime   @default(now())
+  submissionId   String
+  submission     Submission @relation(fields: [submissionId], references: [id])
+}

--- a/styles/RevisionTimeline.module.scss
+++ b/styles/RevisionTimeline.module.scss
@@ -1,0 +1,26 @@
+@import "lbh-frontend/lbh/base";
+
+.timeline {
+  position: relative;
+
+  &:after {
+    content: "";
+    display: block;
+    position: absolute;
+    bottom: 0px;
+    left: 3px;
+    width: 16px;
+    border-bottom: 3px solid lbh-colour("lbh-text");
+  }
+}
+
+.event {
+  &:after {
+    background-color: lbh-colour("lbh-grey-4");
+  }
+
+  &:last-of-type:before {
+    content: "";
+    bottom: 0px;
+  }
+}


### PR DESCRIPTION
this pr adds lightweight google docs-style revision history to submissions

whenever a user updates a submission (by making edits to answers), the app will check if the last revision is more than five minutes old.

if so, it will update the submission _and_ store a new snapshot of:

- who made the revision
- how many steps of the form were complete (allowing us to display % completion)
- when the revision was made

we also display, on the list of unfinished submissions, a timeline of the most recent three revisions to a submission, so users can see who else has been working on it recently.

this _could_ form the mvp of a more complex feature. for example, we don't actually capture the submission as it was during the revision, so restoring older versions isn't possible. if it turns out there's a user need for this sort of thing, we could enhance this feature with it.

landmarks:

- the interval for when to store a new revision is configurable in `/config/app.ts`
- the logic for actually storing revisions is in `/pages/api/submissions/[id]/steps/[stepId].tsx`
- a new component `<RevisionTimeline/>` is responsible for showing the most recent three revisions on the unfinished submissions table